### PR TITLE
Fix black lock screen on GNOME 46+ (lifecycle, lightbox, DPMS)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,7 @@ import St from 'gi://St';
 import Shell from 'gi://Shell';
 import Clutter from 'gi://Clutter';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
 import { Keys } from './enums.js';
 import { PlayerProcess } from './core/player_process.js';
@@ -95,6 +96,7 @@ export default class LockscreenExtension extends Extension {
         this._wrapperActors = {}; // connector -> actor
         this._windowActors = {};  // connector -> actor
         this._lockPositionSignals = [];
+        this._displayWakeTimers = [];
 
         this._promptShown = false;
         this._injectionManager = null;
@@ -437,6 +439,51 @@ export default class LockscreenExtension extends Extension {
             this._player.play();
 
             this._backgroundCreated = true;
+
+            // After the shield becomes active, gnome-settings-daemon
+            // issues a physical DPMS blank on the display (see the
+            // comment in gnome-shell/js/ui/screenShield.js activate():
+            // "when we emit ActiveChanged(true), gnome-settings-daemon
+            // blanks the screen"). Normally the shield's black
+            // lightbox fade hides this, but with lightbox suppression
+            // enabled the monitor can lose signal just as our video
+            // is coming up — especially on slower hardware where the
+            // player subprocess takes ~1s to produce its first frame.
+            //
+            // Force PowerSaveMode back to ON via Mutter's DisplayConfig
+            // D-Bus interface, then repeat on a short timer to fight
+            // any asynchronous blanking g-s-d may still schedule.
+            this._wakeDisplay();
+            for (const delayMs of [100, 300, 700, 1500, 3000]) {
+                const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delayMs, () => {
+                    if (this._lockActive) this._wakeDisplay();
+                    return GLib.SOURCE_REMOVE;
+                });
+                this._displayWakeTimers.push(id);
+            }
+        }
+    }
+
+    _wakeDisplay() {
+        try {
+            Gio.DBus.session.call(
+                'org.gnome.Mutter.DisplayConfig',
+                '/org/gnome/Mutter/DisplayConfig',
+                'org.freedesktop.DBus.Properties',
+                'Set',
+                new GLib.Variant('(ssv)', [
+                    'org.gnome.Mutter.DisplayConfig',
+                    'PowerSaveMode',
+                    new GLib.Variant('i', 0),
+                ]),
+                null,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                null,
+                null
+            );
+        } catch (e) {
+            console.warn('LiveLockScreen: failed to force display wake:', e);
         }
     }
 
@@ -457,6 +504,12 @@ export default class LockscreenExtension extends Extension {
     }
 
     _teardownForUnlock() {
+        // Cancel any pending display-wake timers.
+        for (const id of this._displayWakeTimers) {
+            try { GLib.source_remove(id); } catch (_) { /* already fired */ }
+        }
+        this._displayWakeTimers = [];
+
         for (const { actor, ids } of this._lockPositionSignals) {
             for (const id of ids) {
                 try { actor.disconnect(id); } catch (_) { /* actor gone */ }

--- a/extension.js
+++ b/extension.js
@@ -21,6 +21,7 @@ export default class LockscreenExtension extends Extension {
         this._resetLockState();
         this._lockActive = false;
         this._screenShieldId = 0;
+        this._lightboxInjectionManager = null;
 
         if (!isGtk4PaintableSinkAvailable()) {
             sendErrorNotification(
@@ -31,6 +32,21 @@ export default class LockscreenExtension extends Extension {
         }
 
         this._settings = this.getSettings();
+
+        // Suppress the GNOME screen shield lightbox fade.
+        //
+        // When the shield activates, GNOME fades a black lightbox to
+        // full opacity BEFORE `active-changed` fires. Any video we
+        // then inject into the dialog ends up hidden behind that
+        // opaque overlay, so the user sees a black screen until they
+        // click or move the mouse. Override `lightOn()` on both
+        // lightboxes to still fire their "shown" signal (so the
+        // screen shield state machine advances) but keep their actor
+        // opacity at 0, making the overlay invisible. A dedicated
+        // InjectionManager is used so these overrides persist across
+        // lock/unlock cycles and can be cleanly restored in disable().
+        this._lightboxInjectionManager = new InjectionManager();
+        this._suppressLightboxFade();
 
         // Defer the actual player setup until the screen shield
         // reports it is active. Hooking `Main.screenShield._dialog`
@@ -49,6 +65,29 @@ export default class LockscreenExtension extends Extension {
         // run setup immediately.
         if (Main.screenShield.active)
             this._onActiveChanged();
+    }
+
+    _suppressLightboxFade() {
+        const neuter = (lightbox) => {
+            if (!lightbox) return;
+            this._lightboxInjectionManager.overrideMethod(
+                lightbox, 'lightOn',
+                (original) => {
+                    return function (_fadeInTime) {
+                        // Call original with duration 0 so the
+                        // "shown" signal still fires synchronously
+                        // and the shield state machine advances,
+                        // then force opacity to 0 so the overlay
+                        // never becomes visible.
+                        original.call(this, 0);
+                        this.opacity = 0;
+                    };
+                }
+            );
+        };
+
+        neuter(Main.screenShield._shortLightbox);
+        neuter(Main.screenShield._longLightbox);
     }
 
     _resetLockState() {
@@ -470,6 +509,10 @@ export default class LockscreenExtension extends Extension {
             this._teardownForUnlock();
             this._lockActive = false;
         }
+
+        // Restore original lightbox behavior.
+        this._lightboxInjectionManager?.clear();
+        this._lightboxInjectionManager = null;
 
         this._settings = null;
     }

--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ import {Extension, InjectionManager} from 'resource:///org/gnome/shell/extension
 import St from 'gi://St';
 import Shell from 'gi://Shell';
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 
 import { Keys } from './enums.js';
 import { PlayerProcess } from './core/player_process.js';
@@ -17,14 +18,9 @@ import { sendErrorNotification } from './utils/notifications.js';
 
 export default class LockscreenExtension extends Extension {
     enable() {
-        this._backgroundCreated = false;
-        this._wrapperActors = {}; // connector -> actor 
-        this._windowActors = {};  // connector -> actor
-        this._lockPositionSignals = [];
-
-        this._promptShown = false;
-        this._injectionManager = null;
-        this._player = null;
+        this._resetLockState();
+        this._lockActive = false;
+        this._screenShieldId = 0;
 
         if (!isGtk4PaintableSinkAvailable()) {
             sendErrorNotification(
@@ -36,10 +32,53 @@ export default class LockscreenExtension extends Extension {
 
         this._settings = this.getSettings();
 
+        // Defer the actual player setup until the screen shield
+        // reports it is active. Hooking `Main.screenShield._dialog`
+        // directly at enable() time is unreliable: the dialog object
+        // can be null (never locked yet), or become a dead reference
+        // if GNOME recreates it between enable() and the next lock
+        // cycle. Listening to `active-changed` guarantees we inject
+        // into the current, live dialog on every lock.
+        this._screenShieldId = Main.screenShield.connect(
+            'active-changed',
+            this._onActiveChanged.bind(this)
+        );
+
+        // If the shield is already active at enable() time (e.g. the
+        // user just toggled the extension on from the lock screen),
+        // run setup immediately.
+        if (Main.screenShield.active)
+            this._onActiveChanged();
+    }
+
+    _resetLockState() {
+        this._backgroundCreated = false;
+        this._wrapperActors = {}; // connector -> actor
+        this._windowActors = {};  // connector -> actor
+        this._lockPositionSignals = [];
+
+        this._promptShown = false;
+        this._injectionManager = null;
+        this._player = null;
+    }
+
+    _onActiveChanged() {
+        const active = Main.screenShield.active;
+
+        if (active && !this._lockActive) {
+            this._lockActive = true;
+            this._setupForLock();
+        } else if (!active && this._lockActive) {
+            this._lockActive = false;
+            this._teardownForUnlock();
+        }
+    }
+
+    _setupForLock() {
         const disableOnBatter = this._settings.get_boolean(Keys.DISABLE_ON_BATTERY);
         if (disableOnBatter && isOnBattery()) {
             console.warn('Skipping on battery');
-            return;            
+            return;
         }
 
         const videoPath = this._settings.get_string(Keys.VIDEO_PATH);
@@ -88,7 +127,7 @@ export default class LockscreenExtension extends Extension {
             framerate,
             colorAccurate: colorAccurate
         });
-        
+
         try {
             this._player.run();
         } catch (e) {
@@ -119,48 +158,63 @@ export default class LockscreenExtension extends Extension {
                 this._windowActors[connector] = win.get_compositor_private();
             }
 
-            this._injectCreateBackground();
-
-            this._injectionManager.overrideMethod(
-                Main.screenShield._dialog, '_showPrompt',
-                (original) => {
-                    const self = this;
-                    return function(...args) {
-                        original.call(this, ...args);
-                        self._onPromptShow();
-                    };
-                }
-            );
-
-            this._injectionManager.overrideMethod(
-                Main.screenShield._dialog, '_showClock',
-                (original) => {
-                    const self = this;
-                    return function(...args) {
-                        original.call(this, ...args);
-                        self._onPromptHide();
-                    };
-                }
-            );
-
-            //NOTE: Replacing TapAction with a fresh one if exists (for gnome 48 and older) 
-            const actions = Main.screenShield._dialog.get_actions();
-            const tapAction = actions.find(a => {
-                //HACK: Maybe not the most beautiful solution, but works
-                return a.constructor.name.includes('TapAction')
-            });
-            if (tapAction) {
-                Main.screenShield._dialog.remove_action(tapAction);
-                
-                let newAction = new Clutter.TapAction();
-                newAction.connect('tap', Main.screenShield._dialog._showPrompt.bind(Main.screenShield._dialog));
-                Main.screenShield._dialog.add_action(newAction);
-            }
-
-            Main.screenShield._dialog._updateBackgrounds();
+            this._injectIntoDialog();
         }, (err) => {
             console.error(`Unable to intercept all windows: ${err}`);
         })
+    }
+
+    _injectIntoDialog() {
+        // `active-changed` can fire a hair before `_dialog` is
+        // populated in some GNOME versions. Poll briefly if so.
+        const dialog = Main.screenShield._dialog;
+        if (!dialog) {
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+                if (this._lockActive) this._injectIntoDialog();
+                return GLib.SOURCE_REMOVE;
+            });
+            return;
+        }
+
+        this._injectCreateBackground();
+
+        this._injectionManager.overrideMethod(
+            dialog, '_showPrompt',
+            (original) => {
+                const self = this;
+                return function(...args) {
+                    original.call(this, ...args);
+                    self._onPromptShow();
+                };
+            }
+        );
+
+        this._injectionManager.overrideMethod(
+            dialog, '_showClock',
+            (original) => {
+                const self = this;
+                return function(...args) {
+                    original.call(this, ...args);
+                    self._onPromptHide();
+                };
+            }
+        );
+
+        //NOTE: Replacing TapAction with a fresh one if exists (for gnome 48 and older)
+        const actions = dialog.get_actions();
+        const tapAction = actions.find(a => {
+            //HACK: Maybe not the most beautiful solution, but works
+            return a.constructor.name.includes('TapAction')
+        });
+        if (tapAction) {
+            dialog.remove_action(tapAction);
+
+            let newAction = new Clutter.TapAction();
+            newAction.connect('tap', dialog._showPrompt.bind(dialog));
+            dialog.add_action(newAction);
+        }
+
+        dialog._updateBackgrounds();
     }
 
     _injectCreateBackground() {
@@ -204,7 +258,7 @@ export default class LockscreenExtension extends Extension {
                 });
             })
         }
-        
+
         if (this._promptSettings[Keys.PROMPT_PAUSE])
             this._player?.pause();
     }
@@ -216,7 +270,7 @@ export default class LockscreenExtension extends Extension {
         if (this._promptSettings[Keys.PROMPT_CHANGE_BLUR]) {
             const radius = this._blurRadius;
             const brightness = radius ? this._blurBrightness : 1;
-            
+
             Object.values(this._wrapperActors).forEach(actor => {
                 actor.ease_property('@effects.lockscreen-extension-blur.radius', radius, {
                     duration: this._promptSettings[Keys.PROMPT_BLUR_ANIM_DURATION],
@@ -267,26 +321,26 @@ export default class LockscreenExtension extends Extension {
         const isLastMonitor = monitorIndex === Main.layoutManager.monitors.length - 1;
         const monitor = Main.layoutManager.monitors[monitorIndex];
         const windowActor = this._windowActors[targetConnector];
-        
+
         if (windowActor) {
             const parent = windowActor.get_parent();
             if (parent) parent.remove_child(windowActor);
-            
+
             const wrapper = new Clutter.Actor();
-            
+
             Main.screenShield._dialog._backgroundGroup.add_child(wrapper);
             Main.screenShield._dialog._backgroundGroup.set_child_above_sibling(wrapper, null);
-            
+
             wrapper.add_effect(new Shell.BlurEffect(this._blurEffect));
 
             // Adding color desaturation effect if needed
             if (this._promptSettings[Keys.PROMPT_GRAYSCALE]) {
                 wrapper.add_effect_with_name(
-                    'lockscreen-extension-desaturate', 
+                    'lockscreen-extension-desaturate',
                     new Clutter.DesaturateEffect({ factor: 0.0 })
                 );
             }
-            
+
             if (!this._backgroundCreated)
                 wrapper.opacity = 0;
 
@@ -312,8 +366,8 @@ export default class LockscreenExtension extends Extension {
                 wrapper.set_size(monitor.width, monitor.height);
                 wrapper.set_clip_to_allocation(true);
 
-                // NOTE: 
-                // This might look like an overkill, 
+                // NOTE:
+                // This might look like an overkill,
                 // but you really need to aggressively position actors on any
                 // size/position change
                 const fixPositionAndScale = () => {
@@ -328,16 +382,16 @@ export default class LockscreenExtension extends Extension {
                 const sigW = windowActor.connect('notify::width', fixPositionAndScale);
                 const sigH = windowActor.connect('notify::height', fixPositionAndScale);
                 this._lockPositionSignals.push({ actor: windowActor, ids: [sigX, sigY, sigW, sigH] });
-               
+
                 fixPositionAndScale();
             }
-            
+
             this._wrapperActors[targetConnector] = wrapper;
 
         } else {
             console.warn(`No window actor for monitor ${monitorIndex}, skipping`);
         }
-       
+
         if (!this._backgroundCreated && isLastMonitor) {
             this._initLoginManager();
             this._startAnimation();
@@ -363,20 +417,22 @@ export default class LockscreenExtension extends Extension {
         });
     }
 
-    disable() {
+    _teardownForUnlock() {
         for (const { actor, ids } of this._lockPositionSignals) {
             for (const id of ids) {
-                actor.disconnect(id);
+                try { actor.disconnect(id); } catch (_) { /* actor gone */ }
             }
         }
         this._lockPositionSignals = [];
 
         // Return all window actors to window_group before destroying
         for (const windowActor of Object.values(this._windowActors)) {
-            const parent = windowActor.get_parent();
-            if (parent) parent.remove_child(windowActor);
-            global.window_group.add_child(windowActor);
-            windowActor.hide();
+            try {
+                const parent = windowActor.get_parent();
+                if (parent) parent.remove_child(windowActor);
+                global.window_group.add_child(windowActor);
+                windowActor.hide();
+            } catch (_) { /* actor gone */ }
         }
         this._windowActors = {};
 
@@ -386,17 +442,35 @@ export default class LockscreenExtension extends Extension {
         this._injectionManager?.clear();
         this._injectionManager = null;
 
-        if (this._sleepId) {
+        if (this._sleepId && this._loginManager) {
             this._loginManager.disconnect(this._sleepId);
             this._sleepId = null;
         }
+        this._loginManager = null;
 
         Object.values(this._wrapperActors).forEach(actor => {
-            actor.remove_effect_by_name('lockscreen-extension-blur');
-            actor.remove_effect_by_name('lockscreen-extension-desaturate');
-            actor.destroy()
-        })
+            try {
+                actor.remove_effect_by_name('lockscreen-extension-blur');
+                actor.remove_effect_by_name('lockscreen-extension-desaturate');
+                actor.destroy();
+            } catch (_) { /* already destroyed */ }
+        });
         this._wrapperActors = {};
+        this._backgroundCreated = false;
+        this._promptShown = false;
+    }
+
+    disable() {
+        if (this._screenShieldId) {
+            Main.screenShield.disconnect(this._screenShieldId);
+            this._screenShieldId = 0;
+        }
+
+        if (this._lockActive) {
+            this._teardownForUnlock();
+            this._lockActive = false;
+        }
+
         this._settings = null;
     }
 }


### PR DESCRIPTION
## Summary

Fixes three distinct bugs that cause the extension to show a black lock screen (or lose monitor signal entirely) on GNOME 46+ Wayland. Validated on Raspberry Pi 5 / Ubuntu 24.04 / GNOME Shell 46.0, GJS 1.80.2.

The bugs are independent but compound — fixing one reveals the next. They're split into three commits that can be reviewed in order:

1. `refactor: defer player setup until screen shield is active`
2. `fix: suppress screen shield lightbox fade so video is visible`
3. `fix: force display wake after shield activation`

All upstream behavior is preserved: connector-based window mapping, `_forceFullscreen` debug path, multi-monitor position signals, and the GNOME 48 `TapAction` replacement from #7. No regressions to any existing feature I could find.

---

## Bug 1 — Dialog injection targets a dead/null `_dialog`

### Symptom
On Super+L the screen shield shows for a split second, then goes black. The player subprocess dies shortly after. No video ever appears.

### Root cause
`enable()` calls `waitForWindows` asynchronously, and the callback overrides methods on `Main.screenShield._dialog`. On GNOME 46+ that object is:
- `null` if the extension is enabled before the user has ever locked in this session, and
- a dead reference if GNOME recreates the dialog between `enable()` firing and the next lock cycle (observed during GDM → session handoff on Pi 5).

Either way, our injections land on nothing, `_createBackground` is never wrapped, and the player never gets its windows reparented into the dialog's background group.

### Fix
Hoist the player spawn and dialog injection out of `enable()` into `_setupForLock()`, and run it from a `Main.screenShield.connect('active-changed', …)` handler. Matching `_teardownForUnlock()` runs on unlock and on `disable()`. A short polling fallback in `_injectIntoDialog()` covers the case where `active-changed` fires a hair before `_dialog` is populated.

---

## Bug 2 — Screen shield lightbox hides the video

### Symptom
After fix 1, the video is there but hidden behind a black overlay. Clicking or moving the mouse to bring up the password prompt dismisses the overlay and reveals the video + prompt.

### Root cause
`Main.screenShield._shortLightbox` / `_longLightbox` fade to full opacity **before** `active-changed` fires. The video is injected into `_dialog._backgroundGroup`, which sits underneath the lightbox, so it's visually covered until user input dismisses the overlay.

### Fix
Override `lightOn()` on both lightboxes so it still calls the original with `fadeInTime = 0` (the internal `shown` signal still fires, so the screen shield state machine continues to advance) but forces `opacity = 0` so the overlay is never visible. Uses a dedicated `InjectionManager` held on the extension instance so it persists across lock/unlock cycles and is cleanly cleared on `disable()`.

---

## Bug 3 — gnome-settings-daemon DPMS-blanks the display

### Symptom
After fixes 1 and 2 the clock flashes briefly, then the monitor goes into "No signal" standby and stays there until you move the mouse.

### Root cause
Right there in `gnome-shell/js/ui/screenShield.js activate()`:

> *"when we emit ActiveChanged(true), gnome-settings-daemon blanks the screen"*

So g-s-d does a physical DPMS-off on every shield activation. Normally the lightbox fade hides this — it's already black, so you don't notice the monitor going to sleep. Once we suppress the lightbox (fix 2), the DPMS-off becomes visible on slower hardware where the player subprocess takes ~1s to produce its first frame. On Pi 5 the monitor is already blanked by the time the video starts playing.

### Fix
Call `org.gnome.Mutter.DisplayConfig.PowerSaveMode = 0` via D-Bus immediately after the player starts, then repeat on timers at 100 / 300 / 700 / 1500 / 3000 ms to override any asynchronous blanking g-s-d may still schedule. Timers are cancelled on unlock.

On faster hardware this fix is likely a no-op (the player is already drawing frames before the monitor has time to blank), but it's cheap and defensive.

---

## Test plan

- [x] Lock with Super+L → video appears without clicking
- [x] Unlock with password → returns to desktop cleanly
- [x] Repeated lock/unlock cycles — no leaked timers or injections
- [x] `gnome-extensions disable` while locked — restores original lightbox behavior
- [x] Re-enable after disable — works on next lock
- [ ] Reviewer verification on a non-Pi GNOME 46+ system to confirm the DPMS timers don't cause flicker there

## Environment

- Raspberry Pi 5
- Ubuntu 24.04
- GNOME Shell 46.0
- GJS 1.80.2
- GStreamer 1.24 with `gtk4paintablesink`
- Wayland session
- Extension version 3.1.0 (upstream main at the time of this PR)