### PR TITLE
Fix dialog lifecycle race on GNOME 46+ (refocused follow-up to #9)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,6 +60,9 @@ export default class LockscreenExtension extends Extension {
         this._promptShown = false;
         this._injectionManager = null;
         this._player = null;
+
+        this._injectRetryId = 0;
+        this._injectAttempts = 0;
     }
 
     _onActiveChanged() {
@@ -167,14 +170,30 @@ export default class LockscreenExtension extends Extension {
     _injectIntoDialog() {
         // `active-changed` can fire a hair before `_dialog` is
         // populated in some GNOME versions. Poll briefly if so.
+        //
+        // We cap the retry loop at ~2s worth of 100ms ticks. The
+        // original single-shot 100ms retry was too short on at
+        // least some GNOME 49 setups, where `_dialog` appears to
+        // be recreated on each lock and isn't ready yet on second
+        // and subsequent locks. The retry id is tracked so
+        // `_teardownForUnlock()` can cancel it and avoid firing
+        // injection work into a half-torn-down state.
         const dialog = Main.screenShield._dialog;
         if (!dialog) {
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+            if (this._injectAttempts >= 20) {
+                console.warn('LiveLockScreen: _dialog never appeared after 20 retries, giving up');
+                this._injectAttempts = 0;
+                return;
+            }
+            this._injectAttempts++;
+            this._injectRetryId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+                this._injectRetryId = 0;
                 if (this._lockActive) this._injectIntoDialog();
                 return GLib.SOURCE_REMOVE;
             });
             return;
         }
+        this._injectAttempts = 0;
 
         this._injectCreateBackground();
 
@@ -418,6 +437,14 @@ export default class LockscreenExtension extends Extension {
     }
 
     _teardownForUnlock() {
+        // Cancel any pending dialog-injection retry so it can't fire
+        // into a partially torn-down state or leak across lock cycles.
+        if (this._injectRetryId) {
+            try { GLib.source_remove(this._injectRetryId); } catch (_) {}
+            this._injectRetryId = 0;
+        }
+        this._injectAttempts = 0;
+
         for (const { actor, ids } of this._lockPositionSignals) {
             for (const id of ids) {
                 try { actor.disconnect(id); } catch (_) { /* actor gone */ }

--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ import {Extension, InjectionManager} from 'resource:///org/gnome/shell/extension
 import St from 'gi://St';
 import Shell from 'gi://Shell';
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 
 import { Keys } from './enums.js';
 import { PlayerProcess } from './core/player_process.js';
@@ -17,14 +18,9 @@ import { sendErrorNotification } from './utils/notifications.js';
 
 export default class LockscreenExtension extends Extension {
     enable() {
-        this._backgroundCreated = false;
-        this._wrapperActors = {}; // connector -> actor 
-        this._windowActors = {};  // connector -> actor
-        this._lockPositionSignals = [];
-
-        this._promptShown = false;
-        this._injectionManager = null;
-        this._player = null;
+        this._resetLockState();
+        this._lockActive = false;
+        this._screenShieldId = 0;
 
         if (!isGtk4PaintableSinkAvailable()) {
             sendErrorNotification(
@@ -36,10 +32,53 @@ export default class LockscreenExtension extends Extension {
 
         this._settings = this.getSettings();
 
+        // Defer the actual player setup until the screen shield
+        // reports it is active. Hooking `Main.screenShield._dialog`
+        // directly at enable() time is unreliable: the dialog object
+        // can be null (never locked yet), or become a dead reference
+        // if GNOME recreates it between enable() and the next lock
+        // cycle. Listening to `active-changed` guarantees we inject
+        // into the current, live dialog on every lock.
+        this._screenShieldId = Main.screenShield.connect(
+            'active-changed',
+            this._onActiveChanged.bind(this)
+        );
+
+        // If the shield is already active at enable() time (e.g. the
+        // user just toggled the extension on from the lock screen),
+        // run setup immediately.
+        if (Main.screenShield.active)
+            this._onActiveChanged();
+    }
+
+    _resetLockState() {
+        this._backgroundCreated = false;
+        this._wrapperActors = {}; // connector -> actor
+        this._windowActors = {};  // connector -> actor
+        this._lockPositionSignals = [];
+
+        this._promptShown = false;
+        this._injectionManager = null;
+        this._player = null;
+    }
+
+    _onActiveChanged() {
+        const active = Main.screenShield.active;
+
+        if (active && !this._lockActive) {
+            this._lockActive = true;
+            this._setupForLock();
+        } else if (!active && this._lockActive) {
+            this._lockActive = false;
+            this._teardownForUnlock();
+        }
+    }
+
+    _setupForLock() {
         const disableOnBatter = this._settings.get_boolean(Keys.DISABLE_ON_BATTERY);
         if (disableOnBatter && isOnBattery()) {
             console.warn('Skipping on battery');
-            return;            
+            return;
         }
 
         const videoPath = this._settings.get_string(Keys.VIDEO_PATH);
@@ -88,7 +127,7 @@ export default class LockscreenExtension extends Extension {
             framerate,
             colorAccurate: colorAccurate
         });
-        
+
         try {
             this._player.run();
         } catch (e) {
@@ -119,48 +158,63 @@ export default class LockscreenExtension extends Extension {
                 this._windowActors[connector] = win.get_compositor_private();
             }
 
-            this._injectCreateBackground();
-
-            this._injectionManager.overrideMethod(
-                Main.screenShield._dialog, '_showPrompt',
-                (original) => {
-                    const self = this;
-                    return function(...args) {
-                        original.call(this, ...args);
-                        self._onPromptShow();
-                    };
-                }
-            );
-
-            this._injectionManager.overrideMethod(
-                Main.screenShield._dialog, '_showClock',
-                (original) => {
-                    const self = this;
-                    return function(...args) {
-                        original.call(this, ...args);
-                        self._onPromptHide();
-                    };
-                }
-            );
-
-            //NOTE: Replacing TapAction with a fresh one if exists (for gnome 48 and older) 
-            const actions = Main.screenShield._dialog.get_actions();
-            const tapAction = actions.find(a => {
-                //HACK: Maybe not the most beautiful solution, but works
-                return a.constructor.name.includes('TapAction')
-            });
-            if (tapAction) {
-                Main.screenShield._dialog.remove_action(tapAction);
-                
-                let newAction = new Clutter.TapAction();
-                newAction.connect('tap', Main.screenShield._dialog._showPrompt.bind(Main.screenShield._dialog));
-                Main.screenShield._dialog.add_action(newAction);
-            }
-
-            Main.screenShield._dialog._updateBackgrounds();
+            this._injectIntoDialog();
         }, (err) => {
             console.error(`Unable to intercept all windows: ${err}`);
         })
+    }
+
+    _injectIntoDialog() {
+        // `active-changed` can fire a hair before `_dialog` is
+        // populated in some GNOME versions. Poll briefly if so.
+        const dialog = Main.screenShield._dialog;
+        if (!dialog) {
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+                if (this._lockActive) this._injectIntoDialog();
+                return GLib.SOURCE_REMOVE;
+            });
+            return;
+        }
+
+        this._injectCreateBackground();
+
+        this._injectionManager.overrideMethod(
+            dialog, '_showPrompt',
+            (original) => {
+                const self = this;
+                return function(...args) {
+                    original.call(this, ...args);
+                    self._onPromptShow();
+                };
+            }
+        );
+
+        this._injectionManager.overrideMethod(
+            dialog, '_showClock',
+            (original) => {
+                const self = this;
+                return function(...args) {
+                    original.call(this, ...args);
+                    self._onPromptHide();
+                };
+            }
+        );
+
+        //NOTE: Replacing TapAction with a fresh one if exists (for gnome 48 and older)
+        const actions = dialog.get_actions();
+        const tapAction = actions.find(a => {
+            //HACK: Maybe not the most beautiful solution, but works
+            return a.constructor.name.includes('TapAction')
+        });
+        if (tapAction) {
+            dialog.remove_action(tapAction);
+
+            let newAction = new Clutter.TapAction();
+            newAction.connect('tap', dialog._showPrompt.bind(dialog));
+            dialog.add_action(newAction);
+        }
+
+        dialog._updateBackgrounds();
     }
 
     _injectCreateBackground() {
@@ -204,7 +258,7 @@ export default class LockscreenExtension extends Extension {
                 });
             })
         }
-        
+
         if (this._promptSettings[Keys.PROMPT_PAUSE])
             this._player?.pause();
     }
@@ -216,7 +270,7 @@ export default class LockscreenExtension extends Extension {
         if (this._promptSettings[Keys.PROMPT_CHANGE_BLUR]) {
             const radius = this._blurRadius;
             const brightness = radius ? this._blurBrightness : 1;
-            
+
             Object.values(this._wrapperActors).forEach(actor => {
                 actor.ease_property('@effects.lockscreen-extension-blur.radius', radius, {
                     duration: this._promptSettings[Keys.PROMPT_BLUR_ANIM_DURATION],
@@ -267,26 +321,26 @@ export default class LockscreenExtension extends Extension {
         const isLastMonitor = monitorIndex === Main.layoutManager.monitors.length - 1;
         const monitor = Main.layoutManager.monitors[monitorIndex];
         const windowActor = this._windowActors[targetConnector];
-        
+
         if (windowActor) {
             const parent = windowActor.get_parent();
             if (parent) parent.remove_child(windowActor);
-            
+
             const wrapper = new Clutter.Actor();
-            
+
             Main.screenShield._dialog._backgroundGroup.add_child(wrapper);
             Main.screenShield._dialog._backgroundGroup.set_child_above_sibling(wrapper, null);
-            
+
             wrapper.add_effect(new Shell.BlurEffect(this._blurEffect));
 
             // Adding color desaturation effect if needed
             if (this._promptSettings[Keys.PROMPT_GRAYSCALE]) {
                 wrapper.add_effect_with_name(
-                    'lockscreen-extension-desaturate', 
+                    'lockscreen-extension-desaturate',
                     new Clutter.DesaturateEffect({ factor: 0.0 })
                 );
             }
-            
+
             if (!this._backgroundCreated)
                 wrapper.opacity = 0;
 
@@ -312,8 +366,8 @@ export default class LockscreenExtension extends Extension {
                 wrapper.set_size(monitor.width, monitor.height);
                 wrapper.set_clip_to_allocation(true);
 
-                // NOTE: 
-                // This might look like an overkill, 
+                // NOTE:
+                // This might look like an overkill,
                 // but you really need to aggressively position actors on any
                 // size/position change
                 const fixPositionAndScale = () => {
@@ -328,16 +382,16 @@ export default class LockscreenExtension extends Extension {
                 const sigW = windowActor.connect('notify::width', fixPositionAndScale);
                 const sigH = windowActor.connect('notify::height', fixPositionAndScale);
                 this._lockPositionSignals.push({ actor: windowActor, ids: [sigX, sigY, sigW, sigH] });
-               
+
                 fixPositionAndScale();
             }
-            
+
             this._wrapperActors[targetConnector] = wrapper;
 
         } else {
             console.warn(`No window actor for monitor ${monitorIndex}, skipping`);
         }
-       
+
         if (!this._backgroundCreated && isLastMonitor) {
             this._initLoginManager();
             this._startAnimation();
@@ -363,20 +417,22 @@ export default class LockscreenExtension extends Extension {
         });
     }
 
-    disable() {
+    _teardownForUnlock() {
         for (const { actor, ids } of this._lockPositionSignals) {
             for (const id of ids) {
-                actor.disconnect(id);
+                try { actor.disconnect(id); } catch (_) { /* actor gone */ }
             }
         }
         this._lockPositionSignals = [];
 
         // Return all window actors to window_group before destroying
         for (const windowActor of Object.values(this._windowActors)) {
-            const parent = windowActor.get_parent();
-            if (parent) parent.remove_child(windowActor);
-            global.window_group.add_child(windowActor);
-            windowActor.hide();
+            try {
+                const parent = windowActor.get_parent();
+                if (parent) parent.remove_child(windowActor);
+                global.window_group.add_child(windowActor);
+                windowActor.hide();
+            } catch (_) { /* actor gone */ }
         }
         this._windowActors = {};
 
@@ -386,17 +442,35 @@ export default class LockscreenExtension extends Extension {
         this._injectionManager?.clear();
         this._injectionManager = null;
 
-        if (this._sleepId) {
+        if (this._sleepId && this._loginManager) {
             this._loginManager.disconnect(this._sleepId);
             this._sleepId = null;
         }
+        this._loginManager = null;
 
         Object.values(this._wrapperActors).forEach(actor => {
-            actor.remove_effect_by_name('lockscreen-extension-blur');
-            actor.remove_effect_by_name('lockscreen-extension-desaturate');
-            actor.destroy()
-        })
+            try {
+                actor.remove_effect_by_name('lockscreen-extension-blur');
+                actor.remove_effect_by_name('lockscreen-extension-desaturate');
+                actor.destroy();
+            } catch (_) { /* already destroyed */ }
+        });
         this._wrapperActors = {};
+        this._backgroundCreated = false;
+        this._promptShown = false;
+    }
+
+    disable() {
+        if (this._screenShieldId) {
+            Main.screenShield.disconnect(this._screenShieldId);
+            this._screenShieldId = 0;
+        }
+
+        if (this._lockActive) {
+            this._teardownForUnlock();
+            this._lockActive = false;
+        }
+
         this._settings = null;
     }
 }


### PR DESCRIPTION
Follow-up to #9 — refocused to only the part you indicated you'd consider reviewing again, with a fix attempting to address the GNOME 49 silent-fail you observed.

## What changed vs. #9

The two commits you rejected on scope grounds — the screen shield lightbox override and the Mutter `PowerSaveMode` DPMS wake — have been **dropped from this PR entirely**. I hear you on both counts:

- The lightbox and DPMS fixes go beyond "simple video playback" and step on territory that `Unblank lock screen` already owns. I also confirmed the conflict you described — when both extensions are active, the lightbox override wins and your video never shows. That's clearly not acceptable upstream.
- I'm keeping those two changes as local-only patches on my Pi, where `Unblank` isn't installed and the physical DPMS blank is visible because of the slow first-frame time. They won't come back in this PR.

So this PR contains just the lifecycle refactor (`refactor: defer player setup until screen shield is active`) plus one small follow-up commit that tries to fix the \"works on first lock, silent fail on subsequent\" regression you hit on GNOME 49.

## Commit 1 — lifecycle refactor (unchanged from #9)

Same rationale as before: hooking `Main.screenShield._dialog` directly at `enable()` time is unreliable because the dialog can be null (never locked yet) or a dead reference (recreated between `enable()` and the next lock cycle). Moving the player spawn and injection into a `Main.screenShield::active-changed` handler guarantees we inject into the live dialog every time.

Validated on Raspberry Pi 5 / Ubuntu 24.04 / GNOME Shell 46.0 / GJS 1.80.2 / Wayland. All upstream behavior preserved: connector-based window mapping, `_forceFullscreen` debug path, multi-monitor position signals, and the GNOME 48 `TapAction` replacement from #7.

## Commit 2 — bounded, cancelable retry (new, tries to address your GNOME 49 observation)

**On your feedback re: GNOME 49:**

> It appears to work on the first lock, but then fails silently on subsequent attempts.

I can't reproduce this directly — I don't have a GNOME 49 machine — so I went back and re-read the code for any path that could produce exactly that symptom. I think I found one:

```js
// Original retry, from the first commit:
_injectIntoDialog() {
    const dialog = Main.screenShield._dialog;
    if (!dialog) {
        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
            if (this._lockActive) this._injectIntoDialog();
            return GLib.SOURCE_REMOVE;
        });
        return;
    }
    ...
}
```

Two latent issues here that I missed in #9:

1. **The retry is single-shot.** It schedules exactly one 100ms retry. If `_dialog` isn't populated by the time that one retry fires, the whole injection silently gives up. Nothing logs, nothing throws.
2. **The retry timer id is never saved**, so `_teardownForUnlock()` can't cancel it. If unlock happens while the retry is pending, the retry still fires — potentially into partially-torn-down state.

**Hypothesis for the second-lock symptom on GNOME 49:** on the first lock of a session, `_dialog` is either already present or arrives within 100ms, so the happy path catches it. On unlock, GNOME 49 may tear the dialog down. On the second lock, `_dialog` is recreated asynchronously and is slower than 100ms, so the single retry fires before it's ready and we silently give up. From the user's perspective: first lock shows video, second lock shows the default GNOME lock screen with no error.

This is still a hypothesis — I have no way to verify the exact timing on GNOME 49 from here. But the bounded-retry fix is defensible regardless of whether it turns out to be the root cause:

- Retries up to 20 × 100ms (~2s total) instead of once.
- Tracks the timer id in `this._injectRetryId` and cancels it in `_teardownForUnlock()`.
- Logs a `console.warn` if we exhaust retries, so if it ever fails again the mode is debuggable instead of silent.
- Happy path is unchanged: if `_dialog` is present on the first attempt (as it is on GNOME 46 in my testing), the retry code is never reached.

If this doesn't fix it on your GNOME 49 setup, I'd really appreciate two things:
1. The output of `journalctl --user -b -o cat /usr/bin/gnome-shell | grep -i lockscreen` after a failing lock cycle — the new `console.warn` should reveal whether we're giving up in the retry path or somewhere else entirely.
2. Whether it's the exact same dialog instance on second lock (`Main.screenShield._dialog === <previous>`) or a new one. That'd tell us if the dialog is being recreated at all on 49.

I'm happy to iterate further. I'd rather resolve this for real than force it through.

## Test plan

- [x] GNOME 46 / Wayland / Pi 5: repeated Super+L lock/unlock cycles, no leaked timers or wrapper actors
- [x] `gnome-extensions disable` while locked → cleanly reverts
- [x] `gnome-extensions enable` → works on next lock
- [x] Extension toggled on while already locked (the `Main.screenShield.active` early-run path in `enable()`)
- [ ] **Needs reviewer verification on GNOME 49** — specifically the second and subsequent locks in a session