### PR TITLE
Add fingerprint authentication support via AuthPrompt signals

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -175,6 +175,8 @@ export default class LockscreenExtension extends Extension {
                 };
             }
         );
+
+        this._connectFingerprintAuth(dialog);
         
         // Removing the existing signal to use our custom one
         const swipeSignalId = GObject.signal_lookup('end', gtype);
@@ -208,6 +210,35 @@ export default class LockscreenExtension extends Extension {
         }
 
         dialog._updateBackgrounds();
+    }
+
+    _connectFingerprintAuth(dialog) {
+        const authPrompt = dialog._authPrompt;
+        if (!authPrompt) {
+            warn('AuthPrompt not available, fingerprint detection skipped');
+            return;
+        }
+
+        // When a fingerprint verification message is shown (e.g. "Place your finger")
+        // treat it as a prompt being shown so blur/pause effects apply
+        authPrompt.connectObject(
+            'next', () => {
+                this._onPromptShow();
+            },
+            this
+        );
+
+        // Override _onVerificationComplete to detect successful fingerprint unlock
+        this._injectionManager.overrideMethod(
+            dialog, '_onVerificationComplete',
+            (original) => {
+                const self = this;
+                return function(...args) {
+                    self._onPromptShow();
+                    original.call(this, ...args);
+                };
+            }
+        );
     }
 
     _injectCreateBackground() {
@@ -430,6 +461,7 @@ export default class LockscreenExtension extends Extension {
         this._injectAttempts = 0;
 
         Main.screenShield._dialog._swipeTracker?.disconnectObject(this);
+        Main.screenShield._dialog._authPrompt?.disconnectObject(this);
         this._tapAction?.disconnectObject(this);
 
         // Return all window actors to window_group before destroying


### PR DESCRIPTION
## Motivation

The extension's blur/pause effects only activate when the password prompt is shown, but GNOME's lock screen also supports fingerprint authentication via `fprintd`. Users with fingerprint readers don't get the visual effects during biometric verification.

## Approach

Hooks into the lock dialog's `AuthPrompt` signals to detect fingerprint activity:

- **`authPrompt.next` signal** -- fires when the auth prompt transitions to fingerprint verification (e.g. "Place your finger on the reader"), triggering the same `_onPromptShow()` blur/pause effects as the password prompt.
- **`_onVerificationComplete` override** -- ensures prompt effects apply during a successful fingerprint unlock transition before the screen fully unlocks.
- **Cleanup** -- disconnects the `authPrompt` signals in `disable()` to avoid leaks.

This means fingerprint auth now behaves identically to password auth regarding all prompt-related settings (blur change, pause, grayscale).